### PR TITLE
Fixes console.tron.x replacement to play nice with catch blocks.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,9 +78,14 @@ module.exports = function (babel) {
             pppPath.replaceWith(pppPath.node.arguments[0])
           } else {
             // -=-=-=-=-=-=-=-=-=-=-=-=-=
-            // console.tron.something -- like log, display, etc -- nuke it
+            // console.tron.something -- like log, display, etc
+            //   replace it with a no-op expression so it doesn't break
+            //   catch() statements.
+            //
+            //   TODO(steve): build our own functionDeclaration because
+            //   this isn't the nicest way to achieve this in babel.
             // -=-=-=-=-=-=-=-=-=-=-=-=-=
-            pppPath.remove()
+            pppPath.replaceWithSourceString('(() => false)()')
           }
         } // Identifier
       } // console.tron


### PR DESCRIPTION
So you can remove the `console.tron.log()` expression when it is the only node in a catch block.  This causes a null pointer exception because the `catchExpression`  has a reference to it.

So I'm replacing it with a noop function.

And even this way isn't the best way.  We shouldn't be using `replaceWithSourceString` according to the babel handbook.

