### PR TITLE
Simplify import statement removing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,18 +4,10 @@ module.exports = function (babel) {
   return {
     visitor: {
       ImportDeclaration (path, state) {
-        // -=-=-=-=-=-=-=-=-=-=-=-=-=
-        // nuke all import statements with the word reactotron (including our ReactotronConfig)
-        // -=-=-=-=-=-=-=-=-=-=-=-=-=
-        const value = path.node.source.value
-        if (
-          value &&
-          value.toLowerCase &&
-          value.toLowerCase().indexOf('reactotron') >= 0
-        ) {
+        if (path.node.source.value.toLowerCase().includes('reactotron')) {
           path.remove()
         }
-      }, // ImportDeclaration
+      },
 
       CallExpression (path, state) {
         // -=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ module.exports = function (babel) {
 
   return {
     visitor: {
-      ImportDeclaration (path, state) {
+      ImportDeclaration(path) {
         if (path.node.source.value.toLowerCase().includes('reactotron')) {
           path.remove()
         }


### PR DESCRIPTION
Simplify `ImportDeclaration` part since 
- `path.node.source.value` is always string so no need to check if it has `toLowerCase`
- use `includes` since it is more clear way to check than `indexOf(...) >= 0`
- no need for comment since now it is very obvious what the function is doing
- remove unused parameter